### PR TITLE
Fixed duplicate migration

### DIFF
--- a/db/migrate/20191101205225_create_searches.rb
+++ b/db/migrate/20191101205225_create_searches.rb
@@ -2,7 +2,7 @@ class CreateSearches < ActiveRecord::Migration[6.0]
   def change
     create_table :searches do |t|
       t.string :text
-      t.reference :user, null: false, foreign_key:true
+      t.references :user, null: false, foreign_key:true
       t.timestamps
     end
   end

--- a/db/migrate/20191106065728_add_user_id_to_searches.rb
+++ b/db/migrate/20191106065728_add_user_id_to_searches.rb
@@ -1,5 +1,0 @@
-class AddUserIdToSearches < ActiveRecord::Migration[6.0]
-  def change
-    add_column :searches, :user_id, :integer
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_06_065728) do
+ActiveRecord::Schema.define(version: 2019_11_06_060622) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -35,10 +35,11 @@ ActiveRecord::Schema.define(version: 2019_11_06_065728) do
 
   create_table "searches", force: :cascade do |t|
     t.string "text"
+    t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "score"
-    t.integer "user_id"
+    t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -55,4 +56,5 @@ ActiveRecord::Schema.define(version: 2019_11_06_065728) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "searches", "users"
 end


### PR DESCRIPTION
The last migration was invalid since the "user_id" column is duplicated.

In the first migration, "t.reference" is a type and should actually be "t.references".